### PR TITLE
Remove extraneous log from reading synthesizer test

### DIFF
--- a/tests/unit/reading-synthesizer.test.ts
+++ b/tests/unit/reading-synthesizer.test.ts
@@ -21,7 +21,6 @@ describe("randomMp3Name", () => {
     const input =
       "++@@@!!! çrãzŸ)))   ^^^ test~~~ mañŷ symbølß   123```²³⁴   ♠♥♦♣   →↓←↑   ☺☻♥♦♣   αβγδε   ¿¡   çñ   π∞√∆≤≥≠±   {}|[]";
     const name = randomMp3Name(input);
-    console.log(name);
     expect(name.startsWith("crazy-test-many-symbolss-123-love-")).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- remove stray `console.log` in `reading-synthesizer.test.ts`

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f53e1aa74832581aaaf1eeec9e310