### PR TITLE
feat(instant): add explicit pause multiplier for playback and downloads

### DIFF
--- a/src/components/instant/customize-drawer.tsx
+++ b/src/components/instant/customize-drawer.tsx
@@ -27,6 +27,8 @@ export default function CustomizeDrawer() {
   const [open, setOpen] = useState(false);
   const [storedSettings, setStoredSettings] =
     useLocalStorage<ElevenLabsSettings | null>("custom-voice-settings", null);
+  const [pauseMultiplier, setPauseMultiplier] =
+    useLocalStorage<number>("explicit-pause-multiplier", 1);
   const [apiKey, setApiKey] = useState("");
   const [voiceId, setVoiceId] = useState("");
   const [modelId, setModelId] = useState("");
@@ -148,6 +150,51 @@ export default function CustomizeDrawer() {
         <DrawerContent className="w-[350px]!">
           <ScrollArea className="h-full p-2">
             <div className="p-2">
+              {/* Playback Settings */}
+              <div className="mb-6">
+                <h2 className="mb-1 text-xl tracking-tight">
+                  Pause length
+                </h2>
+                <p className="mb-4 text-sm text-gray-500">
+                  Prolong or shorten pauses in playback and downloads. The times shown below reflect the adjusted pause length.
+                </p>
+                <Label htmlFor="pauseMultiplier" className="mb-1 block text-xs">
+                  Pause length: {(pauseMultiplier ?? 1).toFixed(1)}×
+                </Label>
+                <input
+                  id="pauseMultiplier"
+                  type="range"
+                  min={0.5}
+                  max={3}
+                  step={0.1}
+                  list="pauseMultiplierOptions"
+                  value={pauseMultiplier ?? 1}
+                  onChange={(e) => {
+                    const val = parseFloat((e.target as HTMLInputElement).value);
+                    const allowed = [0.5, 1, 1.5, 2, 3];
+                    const snapped = allowed.reduce((prev, curr) =>
+                      Math.abs(curr - val) < Math.abs(prev - val) ? curr : prev,
+                      allowed[0]
+                    );
+                    setPauseMultiplier(snapped);
+                  }}
+                  className="w-full"
+                />
+                <datalist id="pauseMultiplierOptions">
+                  <option value="0.5" />
+                  <option value="1" />
+                  <option value="1.5" />
+                  <option value="2" />
+                  <option value="3" />
+                </datalist>
+                <div className="mt-1 flex justify-between text-xs text-muted-foreground">
+                  <span>Fast 0.5×</span>
+                  <span>Normal 1.0×</span>
+                  <span>1.5×</span>
+                  <span>Slow 2.0×</span>
+                  <span>Extra Slow 3.0×</span>
+                </div>
+              </div>
               <h2 className="mb-1 text-xl tracking-tight">
                 Custom Voice Settings
               </h2>

--- a/src/components/instant/focus-mode.tsx
+++ b/src/components/instant/focus-mode.tsx
@@ -17,7 +17,21 @@ const events = [
   "tap",
 ];
 
-export function FocusMode({ onExit, activeStep, steps, stepsForPlayer }) {
+type FocusModeProps = {
+  onExit: any;
+  activeStep: any;
+  steps: any;
+  stepsForPlayer: any;
+  pauseMultiplier?: number;
+};
+
+export function FocusMode({
+  onExit,
+  activeStep,
+  steps,
+  stepsForPlayer,
+  pauseMultiplier = 1,
+}: FocusModeProps) {
   const [displayStep, setDisplayStep] = useState(activeStep);
 
   useMount(() => {
@@ -53,7 +67,7 @@ export function FocusMode({ onExit, activeStep, steps, stepsForPlayer }) {
       if (playerStep.type == "pause") {
         setTimeout(() => {
           setDisplayStep(nextStep);
-        }, playerStep.duration * 1000 - 1500);
+        }, Math.max(0, Math.round(Number(playerStep.duration ?? 0)) * 1000 - 1500));
       }
     }
   });
@@ -125,7 +139,7 @@ const OverlayContent = React.memo(function OverlayContent({
               <div>{stepText}</div>
             ) : stepType === "pause" ? (
               <div className="text-muted-foreground/70 italic">
-                {stepDuration}s pause
+                {Math.round(Number(stepDuration ?? 0))}s pause
               </div>
             ) : null}
           </motion.div>

--- a/src/components/instant/instant-page.tsx
+++ b/src/components/instant/instant-page.tsx
@@ -42,6 +42,10 @@ export default function ReaderPage() {
   const downloadAbortControllerRef = useRef<AbortController | null>(null);
   const scriptTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [customSettings] = useLocalStorage("custom-voice-settings", null);
+  const [explicitPauseMultiplier] = useLocalStorage(
+    "explicit-pause-multiplier",
+    1
+  );
   const [hasMounted, setHasMounted] = useState(false);
   const [improvePauses, setImprovePauses] = useState(true);
   const [selectedVoice, setSelectedVoice] = useAtom(voiceIdAtom);
@@ -88,6 +92,7 @@ export default function ReaderPage() {
             ? { settings: voiceSettings }
             : {}),
           improvePauses,
+          explicitPauseMultiplier,
           language: selectedLanguage,
         }),
         signal: controller.signal,
@@ -175,6 +180,7 @@ export default function ReaderPage() {
             ? { settings: voiceSettings }
             : {}),
           improvePauses,
+          explicitPauseMultiplier,
           language: selectedLanguage,
         }),
         signal: controller.signal,

--- a/src/components/instant/reading-drawer-content.tsx
+++ b/src/components/instant/reading-drawer-content.tsx
@@ -311,7 +311,7 @@ export function ReadingDrawerContent({
                 {step.type === "speech" && <p>{step.text}</p>}
                 {step.type === "pause" && (
                   <p className="text-muted-foreground/70 italic">
-                    {step.duration}s pause
+                    {Math.round(Number(step.duration ?? 0))}s pause
                   </p>
                 )}
               </div>


### PR DESCRIPTION
Hello there,

While doing meditations for myself, I've found really desiring the voice to slow way down while doing things like body scans or emotional regulation. Thus I implemented the feature myself - it's a simple scaler of the pauses already generated (0.5-3x).

## Summary
Adds an explicit pause length multiplier to Instant Reading/Meditation playback and downloads, letting users shorten or prolong pauses (without regenerating content).

## What’s Included
- UI: Pause length slider in [customize-drawer.tsx](src/components/instant/customize-drawer.tsx:1), persisted in localStorage.
- Client: [instant-page.tsx](src/components/instant/instant-page.tsx:1) sends explicitPauseMultiplier with requests.
- API: [start-reading.ts](src/pages/api/start-reading.ts:1) clamps (0.5–3.0) and snaps to [0.5, 1, 1.5, 2, 3].
- Engine: [reading-synthesizer.ts](src/lib/reading-synthesizer.ts:1) scales pause audio without mutating original step data; augments runtime metadata; reuses cached silent MP3s.
- UI Rendering: [reading-drawer-content.tsx](src/components/instant/reading-drawer-content.tsx:1) and [focus-mode.tsx](src/components/instant/focus-mode.tsx:1) display rounded seconds for pauses.

## Behavior
- Defaults to 1.0 (no change) for full backward compatibility.
- Multiplier consistently affects live playback and concatenated MP3 downloads.
- Server-side validation prevents extreme or unexpected timings.